### PR TITLE
Login should use session without remember_me

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,12 @@ class ApplicationController < ActionController::Base
   private
 
   # current_member : -> nil or Member
-  # Looks up the current member from the cookies :auth_token.
+  # Looks up the current member from the cookies/session :auth_token.
   # The result is cached in the instance variable @current_member.
   #
   def current_member
-    if cookies[:auth_token]
-      @current_member ||= Member.find_by_auth_token(cookies[:auth_token])
+    if auth_token = session[:auth_token] || cookies[:auth_token]
+      @current_member ||= Member.find_by_auth_token(auth_token)
     end
   end
   helper_method :current_member
@@ -49,27 +49,27 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in!
 
   # login! : Member -> Boolean
-  # Sets the :auth_token on the cookies. Effectively logging
+  # Sets the :auth_token on the cookies/session. Effectively logging
   # the member in.
   #
   # Options:
   # :remember_me - Sets a permanent cookie.
   #
   def login!(member, options = {})
+    session[:auth_token] = member.auth_token
+
     if options[:remember_me]
       cookies.permanent[:auth_token] = member.auth_token
-    else
-      cookies[:auth_token] = member.auth_token
     end
   end
   helper_method :login!
 
   # logout! : -> Boolean
-  # Clears the :auth_token from the cookies. If there is not a
-  # :auth_token, return false. Otherwise true.
+  # Clears the :auth_token from the cookies/session.
   #
   def logout!
-    cookies[:auth_token] ? !cookies[:auth_token] = nil : false
+    session[:auth_token] = nil
+    cookies[:auth_token] = nil
   end
   helper_method :logout!
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -24,7 +24,7 @@ describe SessionsController do
 
       it "creates a new session" do
         post :create, params
-        @controller.send(:logged_in?, {:as_member => member}).should be_true
+        @controller.send(:logged_in?, :as_member => member).should be_true
       end
 
       it "redirects to home view" do
@@ -40,7 +40,22 @@ describe SessionsController do
       it "sets a cookie" do
         member = Member.find_by_email(params[:email])
         post :create, params
-        cookies[:auth_token].should eq(member.auth_token)
+        session[:auth_token].should eq(member.auth_token)
+      end
+
+      context "remembered" do
+        before { params.merge!(:remember_me => true) }
+
+        it "creates a new session" do
+          post :create, params
+          @controller.send(:logged_in?, :as_member => member).should be_true
+        end
+
+        it "sets a cookie" do
+          member = Member.find_by_email(params[:email])
+          post :create, params
+          cookies[:auth_token].should eq(member.auth_token)
+        end
       end
     end
 
@@ -72,9 +87,10 @@ describe SessionsController do
       @controller.send(:logged_in?).should_not be_true
     end
 
-    it "removes the auth_token from the cookie" do
+    it "removes the auth_token from the cookie/session" do
       delete :destroy
       cookies[:auth_token].should be_nil
+      session[:auth_token].should be_nil
     end
 
     it "redirects to home view" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -37,7 +37,7 @@ describe SessionsController do
         flash[:notice].should_not be_nil
       end
 
-      it "sets a cookie" do
+      it "sets a session" do
         member = Member.find_by_email(params[:email])
         post :create, params
         session[:auth_token].should eq(member.auth_token)


### PR DESCRIPTION
At the moment a cookie is always used to save the `auth_token`. The site should save the `auth_token` in a session always, and persist the session with a cookie.
