### PR TITLE
Server Scripts

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,14 @@
+# Run the server unattached to the terminal.
+daemonize true
+
+# Redirect logs.
+stdout_redirect 'log/puma.log', 'log/puma.err'
+
+# Specify quantity of threads.
+threads 0, 16
+
+if ENV['RAILS_ENV'] == "production"
+  bind "unix://tmp/sockets/puma.sock"
+else
+  port 3000
+end

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -1,5 +1,19 @@
 # These are rake tasks for managing the rails server.
 
+# Prints to the screen. Levels are :default,
+# :success, :warning, and :error.
+def say(message, level=:default)
+  string = if level == :default
+    message
+  else
+    prefix = "[#{level.capitalize}]"
+    "#{prefix} #{message}"
+  end
+
+  puts string
+end
+
+# Wrap the server control functionality.
 class Server
   # Define a collection of services the server uses to
   # check.
@@ -14,6 +28,21 @@ class Server
   end
 
   class << self
+    def start
+      say "Starting server..."
+      [true, false].sample
+    end
+
+    def stop
+      say "Stoping server..."
+      [true, false].sample
+    end
+
+    def hot_restart
+      say "Hot Restarting server..."
+      [true, false].sample
+    end
+
     def running?
       result = true
       SERVICES.each do |_, check|
@@ -27,19 +56,6 @@ class Server
       define_method("#{name}?", check)
     end
   end
-end
-
-# Prints to the screen. Levels are :default,
-# :success, :warning, and :error.
-def say(message, level=:default)
-  string = if level == :default
-    message
-  else
-    prefix = "[#{level.capitalize}]"
-    "#{prefix} #{message}"
-  end
-
-  puts string
 end
 
 namespace :server do
@@ -58,10 +74,7 @@ namespace :server do
     if Server.running?
       say "Server is already running.", :warning
     else
-
-      # TODO: Start the server here.
-
-      if Server.running?
+      if Server.start
         say "Server started.", :success
       else
         say "Starting server failed.", :error
@@ -72,13 +85,10 @@ namespace :server do
   desc "Stop the server, if it's not running just say that."
   task :stop do
     if Server.running?
-
-      # TODO: Stop the server here.
-
-      if Server.running?
-        say "Stopping server failed.", :error
-      else
+      if Server.stop
         say "Server stopped.", :success
+      else
+        say "Stopping server failed.", :error
       end
     else
       say "Server is already stopped.", :warning
@@ -105,10 +115,7 @@ namespace :server do
     desc "Hot Restart the server without ever taking it down."
     task :hot do
       if Server.running?
-
-        # TODO: Restart the server here.
-
-        if Server.running?
+        if Server.hot_restart
           say "Server hot restarted.", :success
         else
           say "Hot restarting server failed.", :error

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -29,6 +29,12 @@ class Server
 
   class << self
 
+    # Read the PID from the PID_FILE. This is the current
+    # process id for the rails server.
+    def pid
+      File.read(PID_FILE)
+    end
+
     # Start the server, using `rails`. This will deamonize it, and
     # create a pid file for the server in tmp/pids
     def start
@@ -39,14 +45,12 @@ class Server
     end
 
     def stop
-      pid = File.read(PID_FILE)
       system "kill #{pid} > /dev/null 2>&1"
       sleep(0.1)
       not rails?
     end
 
     def hot_restart
-      pid = File.read(PID_FILE)
       system "kill -signal_name USR2 #{pid} > /dev/null 2>&1"
     end
 

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -1,7 +1,4 @@
-# This is the command run after every git clone/pull.
-# We need to ensure all the setup is done, and start
-# the server. With Puma we can restart while live
-# by sending the Puma server a signal.
+# These are rake tasks for managing the rails server.
 
 class Server
   # Define a collection of services the server uses to

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -1,0 +1,92 @@
+# This is the command run after every git clone/pull.
+# We need to ensure all the setup is done, and start
+# the server. With Puma we can restart while live
+# by sending the Puma server a signal.
+
+class Server
+  # Define a collection of services the server uses to
+  # check.
+  SERVICES = {}
+
+  SERVICES[:puma] = -> do
+    [true, false].sample
+  end
+
+  SERVICES[:postgres] = -> do
+    [true, false].sample
+  end
+
+  class << self
+    def running?
+      result = true
+      SERVICES.each do |_, check|
+        result &&= check.call
+      end
+      result
+    end
+
+    # Define predicate methods for each service.
+    SERVICES.each do |name, check|
+      define_method("#{name}?", check)
+    end
+  end
+end
+
+namespace :server do
+
+  desc "Get the status of the servers parts."
+  task :status do
+    if Server.running?
+      puts "Server is running."
+    else
+      puts "Server is not running."
+    end
+  end
+
+  desc "Start up the server, if the server is already up just say that."
+  task :start do
+    if puma?
+      puts "Server is already running."
+    else
+      puts "Starting the server..."
+    end
+  end
+
+  desc "Stop the server, if it's not running just say that."
+  task :stop do
+    if puma?
+      puts "Stopping the server..."
+    else
+      puts "Server is already stopped."
+    end
+  end
+
+  desc "Restart the server, trying hot first, then cold."
+  task :restart do
+    if puma?
+      begin
+        run "server:restart:hot"
+      rescue
+        run "server:restart:cold"
+      end
+    else
+      run "server:restart:cold"
+    end
+  end
+
+  namespace :restart do
+    desc "Restart the server, if it's not running just say that."
+    task :cold => [:stop, :start] do
+    end
+
+    desc "Hot Restart the server without ever taking it down."
+    task :hot do
+      if puma?
+        puts "Hot restarting the server..."
+      else
+        puts "Server is not running."
+      end
+    end
+  end
+
+end

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -32,38 +32,65 @@ class Server
   end
 end
 
+# Prints to the screen. Levels are :default,
+# :success, :warning, and :error.
+def say(message, level=:default)
+  string = if level == :default
+    message
+  else
+    prefix = "[#{level.capitalize}]"
+    "#{prefix} #{message}"
+  end
+
+  puts string
+end
+
 namespace :server do
 
   desc "Get the status of the servers parts."
   task :status do
     if Server.running?
-      puts "Server is running."
+      say "Server is running."
     else
-      puts "Server is not running."
+      say "Server is not running."
     end
   end
 
   desc "Start up the server, if the server is already up just say that."
   task :start do
-    if puma?
-      puts "Server is already running."
+    if Server.running?
+      say "Server is already running.", :warning
     else
-      puts "Starting the server..."
+
+      # TODO: Start the server here.
+
+      if Server.running?
+        say "Server started.", :success
+      else
+        say "Starting server failed.", :error
+      end
     end
   end
 
   desc "Stop the server, if it's not running just say that."
   task :stop do
-    if puma?
-      puts "Stopping the server..."
+    if Server.running?
+
+      # TODO: Stop the server here.
+
+      if Server.running?
+        say "Stopping server failed.", :error
+      else
+        say "Server stopped.", :success
+      end
     else
-      puts "Server is already stopped."
+      say "Server is already stopped.", :warning
     end
   end
 
   desc "Restart the server, trying hot first, then cold."
   task :restart do
-    if puma?
+    if Server.running?
       begin
         run "server:restart:hot"
       rescue
@@ -76,15 +103,21 @@ namespace :server do
 
   namespace :restart do
     desc "Restart the server, if it's not running just say that."
-    task :cold => [:stop, :start] do
-    end
+    task :cold => [:stop, :start]
 
     desc "Hot Restart the server without ever taking it down."
     task :hot do
-      if puma?
-        puts "Hot restarting the server..."
+      if Server.running?
+
+        # TODO: Restart the server here.
+
+        if Server.running?
+          say "Server hot restarted.", :success
+        else
+          say "Hot restarting server failed.", :error
+        end
       else
-        puts "Server is not running."
+        say "Server is not running.", :error
       end
     end
   end

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -17,7 +17,7 @@ end
 class Server
 
   # Location for the rails PID file.
-  PID_FILE = "tmp/pids/server.pid"
+  PID_FILE = "tmp/pids/puma.pid"
 
   # Define a collection of services the server uses to
   # check.
@@ -38,8 +38,8 @@ class Server
     # Start the server, using `rails`. This will deamonize it, and
     # create a pid file for the server in tmp/pids
     def start
-      flags = "--daemon"
-      system "rails server #{flags} > /dev/null 2>&1"
+      flags = "--config config/puma.rb --pidfile #{PID_FILE}"
+      system "puma #{flags} > /dev/null 2>&1"
       sleep(0.1)
       rails?
     end
@@ -54,7 +54,7 @@ class Server
     # Send Puma the signal to start spawning new versions of the server
     # from updated code.
     def hot_restart
-      system "kill -signal_name USR2 #{pid} > /dev/null 2>&1"
+      system "kill -s USR2 #{pid} > /dev/null 2>&1"
     end
 
     # Return true when all of the services are true.

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -44,16 +44,20 @@ class Server
       rails?
     end
 
+    # Stop the server, simply kill it by it's PID.
     def stop
       system "kill #{pid} > /dev/null 2>&1"
       sleep(0.1)
       not rails?
     end
 
+    # Send Puma the signal to start spawning new versions of the server
+    # from updated code.
     def hot_restart
       system "kill -signal_name USR2 #{pid} > /dev/null 2>&1"
     end
 
+    # Return true when all of the services are true.
     def running?
       result = true
       SERVICES.each do |_, check|


### PR DESCRIPTION
I've created a few rake tasks to assist with the server management. I'm assuming puppet will handle all of the nginx, postgres, and environment/users. This script will simply be for starting, stopping, and restarting the server.

This means that puppet needs to deal with `RAILS_ENV`, `MAILCHIMP_API_KEY` and `SECRET_KEY` in the ENV.
## Usage

To show the current status of the server run: `rake server:status`

To start the Puma server run: `rake server:start`

To stop the Puma server run: `rake server:stop`

To perform a cold restart of the server (stop then start) run: `rake server:restart:cold`

To perform a hot restart of the server (0 downtime) run: `rake server:restart:hot`
## Moving Forward

I'd like there to be a little more system checking added to this. It would be nice to get status of all the parts of the system here, like postgres and nginx. Also getting some info about usage and load could be nice.
